### PR TITLE
Singleplayer support + history system

### DIFF
--- a/BoomBoxCartMod/Boombox/Boombox.cs
+++ b/BoomBoxCartMod/Boombox/Boombox.cs
@@ -12,7 +12,7 @@ using System.Linq;
 using Photon.Realtime;
 using System.Xml;
 
-namespace BoomboxCartMod
+namespace BoomBoxCartMod
 {
 	public class Boombox : MonoBehaviourPunCallbacks
 	{

--- a/BoomBoxCartMod/Boombox/Boombox.cs
+++ b/BoomBoxCartMod/Boombox/Boombox.cs
@@ -2,7 +2,6 @@
 using UnityEngine;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using BoomBoxCartMod.Util;
 using UnityEngine.Networking;
 using System;
 using System.IO;
@@ -10,8 +9,10 @@ using BepInEx.Logging;
 using System.Text.RegularExpressions;
 using System.Collections;
 using System.Linq;
+using Photon.Realtime;
+using System.Xml;
 
-namespace BoomBoxCartMod
+namespace BoomboxCartMod
 {
 	public class Boombox : MonoBehaviourPunCallbacks
 	{
@@ -70,6 +71,8 @@ namespace BoomBoxCartMod
 		// SoundCloud URLs
 		new Regex(@"^((?:https?:)?\/\/)?((?:www|m)\.)?(soundcloud\.com|snd\.sc)\/([\w\-]+\/[\w\-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase)
 		};
+		private static readonly string historyFilePath = Path.Combine(Directory.GetCurrentDirectory(), "BoomboxedCart/history.txt");
+		public static HistoryEntry[] historyEntries = new HistoryEntry[0];
 
 		private void Awake()
 		{
@@ -117,6 +120,7 @@ namespace BoomBoxCartMod
 			}
 
 			Logger.LogInfo($"Boombox initialized on this cart. AudioSource: {audioSource}, PhotonView: {photonView}");
+			loadHistory();
 		}
 
 		private void Update()
@@ -218,6 +222,9 @@ namespace BoomBoxCartMod
 				{
 					var (filePath, title) = await YoutubeDL.DownloadAudioWithTitleAsync(url);
 
+
+					addToHistory(url, songTitles.ContainsKey(url) ? songTitles[url] : title);
+
 					songTitles[url] = title;
 					photonView.RPC("SetSongTitle", RpcTarget.AllBuffered, url, title);
 					//Logger.LogInfo($"Set song title for url: {url} to {title}");
@@ -266,7 +273,10 @@ namespace BoomBoxCartMod
 				(PhotonNetwork.IsMasterClient && (requesterId != PhotonNetwork.LocalPlayer.ActorNumber || isTimeoutRecovery)))
 			{
 				//Logger.LogInfo("Waiting for all players to be ready for playback...");
-				await WaitForPlayersReadyOrFailed(url);
+				if (PhotonNetwork.IsConnected)
+				{
+					await WaitForPlayersReadyOrFailed(url);
+				}
 
 				// check if current request ID is still valid (prob wont happen)
 				if (currentRequestId != requestId)
@@ -284,7 +294,16 @@ namespace BoomBoxCartMod
 				}
 
 				Logger.LogInfo($"All players ready for playback. Initiating sync playback for {downloadsReady[url].Count} players.");
-				photonView.RPC("SyncPlayback", RpcTarget.All, url, requesterId);
+				if (PhotonNetwork.IsConnected)
+				{
+					photonView.RPC("SyncPlayback", RpcTarget.All, url, requesterId);
+				} else
+				{
+					// singleplayer
+					SyncPlayback(url, requesterId);
+				}
+				
+
 			}
 
 			if (timeoutCoroutines.TryGetValue(requestId, out Coroutine coroutine) && coroutine != null)
@@ -311,6 +330,8 @@ namespace BoomBoxCartMod
 		[PunRPC]
 		public void ReportDownloadError(int actorNumber, string url, string errorMessage)
 		{
+
+			isDownloadInProgress = false;
 			Logger.LogError($"Player {actorNumber} reported download error for {url}: {errorMessage}");
 
 			if (!downloadErrors.ContainsKey(url))
@@ -320,6 +341,7 @@ namespace BoomBoxCartMod
 
 			if (actorNumber == PhotonNetwork.LocalPlayer.ActorNumber)
 			{
+				
 				UpdateUIStatus($"Error: {errorMessage}");
 			}
 		}
@@ -607,6 +629,7 @@ namespace BoomBoxCartMod
 				ui.UpdateStatus(message);
 			}
 		}
+		
 
 		public override void OnPlayerLeftRoom(Photon.Realtime.Player otherPlayer)
 		{
@@ -705,5 +728,78 @@ namespace BoomBoxCartMod
 				return clip;
 			}
 		}
+		public static bool hasHistory()
+		{
+			return historyEntries != null && historyEntries.Length > 0;
+		}
+		public static void addToHistory(string url, string title)
+		{
+			if (historyEntries.Any(entry => entry.url == url))
+			{
+				return;
+			}
+			HistoryEntry newEntry = new HistoryEntry(url, title);
+			historyEntries = historyEntries.Append(newEntry).ToArray();
+
+			// enforce max history size of 10
+			if (historyEntries.Length > 10)
+			{
+				historyEntries = historyEntries.Skip(historyEntries.Length - 10).ToArray();
+			}
+
+			saveHistory();
+		}
+		public static void clearHistory()
+		{
+			historyEntries = new HistoryEntry[0];
+			saveHistory();
+		}
+		public static void loadHistory()
+		{
+			if (File.Exists(historyFilePath))
+			{
+				FileStream fs = new FileStream(historyFilePath, FileMode.Open, FileAccess.Read);
+				XmlReader xmlReader = XmlReader.Create(fs);
+				xmlReader.ReadToFollowing("HistoryEntries");
+				if (xmlReader.ReadToDescendant("HistoryEntry"))
+				{
+					List<HistoryEntry> newEntries = new List<HistoryEntry>();
+					do
+					{
+						string url = xmlReader.GetAttribute("Url");
+						string title = xmlReader.GetAttribute("Title");
+						if (!string.IsNullOrEmpty(url) && !string.IsNullOrEmpty(title))
+						{
+							newEntries.Add(new HistoryEntry(url, title));
+						}
+					} while (xmlReader.ReadToNextSibling("HistoryEntry"));
+					historyEntries = newEntries.ToArray();
+				}
+				else
+				{
+					Logger.LogInfo("history.txt is empty!");
+				}
+			}
+		}
+		public static void saveHistory()
+		{
+			using (FileStream fs = new FileStream(historyFilePath, FileMode.Create, FileAccess.Write))
+			using (XmlWriter xmlWriter = XmlWriter.Create(fs, new XmlWriterSettings { Indent = true }))
+			{
+				xmlWriter.WriteStartDocument();
+				xmlWriter.WriteStartElement("HistoryEntries");
+				foreach (var entry in historyEntries)
+				{
+					xmlWriter.WriteStartElement("HistoryEntry");
+					xmlWriter.WriteAttributeString("Url", entry.url);
+					xmlWriter.WriteAttributeString("Title", entry.title);
+					xmlWriter.WriteEndElement();
+				}
+				xmlWriter.WriteEndElement();
+				xmlWriter.WriteEndDocument();
+			}
+			Logger.LogInfo($"Saved {historyEntries.Length} history entries to {historyFilePath}");
+		}
+		
 	}
 }

--- a/BoomBoxCartMod/Boombox/BoomboxController.cs
+++ b/BoomBoxCartMod/Boombox/BoomboxController.cs
@@ -2,10 +2,10 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 using BepInEx.Logging;
-using BoomBoxCartMod.Patches;
+using BoomboxCartMod.Patches;
 using System;
 
-namespace BoomBoxCartMod
+namespace BoomboxCartMod
 {
 	public class BoomboxController : MonoBehaviourPun
 	{
@@ -53,6 +53,11 @@ namespace BoomBoxCartMod
 			//Logger.LogInfo($"Local player {localPlayerId} requesting boombox control");
 
 			photonView.RPC("RequestControl", RpcTarget.MasterClient, localPlayerId);
+			if (!PhotonNetwork.IsConnected)
+			{
+				// singleplayer
+				SetController(localPlayerId);
+			}
 		}
 
 		[PunRPC]
@@ -131,8 +136,15 @@ namespace BoomBoxCartMod
 		{
 			if (currentControllerId == PhotonNetwork.LocalPlayer.ActorNumber)
 			{
-				//Logger.LogInfo($"Player {PhotonNetwork.LocalPlayer.ActorNumber} releasing boombox control");
-				photonView.RPC("RequestRelease", RpcTarget.MasterClient, PhotonNetwork.LocalPlayer.ActorNumber);
+				if (PhotonNetwork.IsConnected)
+				{
+					photonView.RPC("RequestRelease", RpcTarget.MasterClient, PhotonNetwork.LocalPlayer.ActorNumber);
+				}
+				else
+				{
+					//singleplayer
+					RequestRelease(PhotonNetwork.LocalPlayer.ActorNumber);
+				}
 			}
 		}
 
@@ -144,8 +156,16 @@ namespace BoomBoxCartMod
 
 			if (currentControllerId == releaserId)
 			{
-				//Logger.LogInfo($"Master client processing release request from player {releaserId}");
-				photonView.RPC("SetController", RpcTarget.All, -1);
+				if (PhotonNetwork.IsConnected)
+				{
+					//Logger.LogInfo($"Master client processing release request from player {releaserId}");
+					photonView.RPC("SetController", RpcTarget.All, -1);
+				}
+				else
+				{
+					//singleplayer
+					SetController(-1);
+				}
 			}
 		}
 

--- a/BoomBoxCartMod/Boombox/BoomboxController.cs
+++ b/BoomBoxCartMod/Boombox/BoomboxController.cs
@@ -2,10 +2,10 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 using BepInEx.Logging;
-using BoomboxCartMod.Patches;
+using BoomBoxCartMod.Patches;
 using System;
 
-namespace BoomboxCartMod
+namespace BoomBoxCartMod
 {
 	public class BoomboxController : MonoBehaviourPun
 	{

--- a/BoomBoxCartMod/Boombox/BoomboxUI.cs
+++ b/BoomBoxCartMod/Boombox/BoomboxUI.cs
@@ -4,11 +4,11 @@ using Photon.Pun;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.XR;
 using BepInEx.Logging;
-using BoomboxCartMod;
+using BoomBoxCartMod;
 using System;
 using Photon.Chat;
 
-namespace BoomboxCartMod
+namespace BoomBoxCartMod
 {
 	public class BoomboxUI : MonoBehaviourPun
 	{

--- a/BoomBoxCartMod/Boombox/BoomboxUI.cs
+++ b/BoomBoxCartMod/Boombox/BoomboxUI.cs
@@ -4,9 +4,11 @@ using Photon.Pun;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.XR;
 using BepInEx.Logging;
+using BoomboxCartMod;
 using System;
+using Photon.Chat;
 
-namespace BoomBoxCartMod
+namespace BoomboxCartMod
 {
 	public class BoomboxUI : MonoBehaviourPun
 	{
@@ -57,6 +59,7 @@ namespace BoomBoxCartMod
 		private bool previousCursorVisible;
 		private bool stylesInitialized = false;
 		private Vector2 scrollPosition = Vector2.zero;
+		private Vector2 historyScrollPosition = Vector2.zero;
 
 		private bool shouldClearFocus = false;
 
@@ -82,7 +85,7 @@ namespace BoomBoxCartMod
 					Logger.LogError("BoomboxUI: Failed to find PhotonView component");
 				}
 
-				windowRect = new Rect(Screen.width / 2 - 200, Screen.height / 2 - 175, 400, 550);
+				windowRect = new Rect(Screen.width / 2 - 200, Screen.height / 2 - 175, 400, 590 + Boombox.historyEntries.Length * 35);
 
 				//Logger.LogInfo($"BoomboxUI initialized. Boombox: {boombox}, PhotonView: {photonView}, Controller: {controller}");
 			}
@@ -466,7 +469,15 @@ namespace BoomBoxCartMod
 			{
 				if (IsValidVideoUrl(urlInput))
 				{
-					photonView.RPC("RequestSong", RpcTarget.All, urlInput, PhotonNetwork.LocalPlayer.ActorNumber);
+					if (PhotonNetwork.IsConnected)
+					{
+						photonView.RPC("RequestSong", RpcTarget.All, urlInput, PhotonNetwork.LocalPlayer.ActorNumber);
+					}
+					else
+					{
+						//singleplayer
+						boombox.RequestSong(urlInput, PhotonNetwork.LocalPlayer.ActorNumber);
+					}
 					GUI.FocusControl(null);
 				}
 				else
@@ -479,7 +490,24 @@ namespace BoomBoxCartMod
 			GUI.enabled = boombox != null && boombox.isPlaying;
 			if (GUILayout.Button("\u25A0 STOP", buttonStyle, GUILayout.Height(40)))
 			{
-				photonView.RPC("StopPlayback", RpcTarget.All, PhotonNetwork.LocalPlayer.ActorNumber);
+				if (PhotonNetwork.IsConnected)
+				{
+					if (PhotonNetwork.IsConnected)
+					{
+						photonView.RPC("StopPlayback", RpcTarget.All, PhotonNetwork.LocalPlayer.ActorNumber);
+					}
+					else
+					{
+						//singleplayer
+						boombox.StopPlayback(PhotonNetwork.LocalPlayer.ActorNumber);
+					}
+				}
+				else
+				{
+					//singleplayer
+					boombox.StopPlayback(PhotonNetwork.LocalPlayer.ActorNumber);
+				}
+
 				GUI.FocusControl(null);
 			}
 			GUI.enabled = true;
@@ -502,6 +530,11 @@ namespace BoomBoxCartMod
 			GUILayout.FlexibleSpace();
 			if (GUILayout.Button("Close", buttonStyle, GUILayout.Width(100), GUILayout.Height(30)))
 			{
+				if (!PhotonNetwork.IsConnected)
+				{
+					// singleplayer
+					HideUI();
+				}
 				if (controller != null)
 				{
 					controller.ReleaseControl();
@@ -514,6 +547,49 @@ namespace BoomBoxCartMod
 			GUILayout.FlexibleSpace();
 			GUILayout.EndHorizontal();
 
+				historyScrollPosition = GUILayout.BeginScrollView(historyScrollPosition, false, false, GUILayout.ExpandHeight(true));
+			GUILayout.FlexibleSpace();
+			if (Boombox.historyEntries.Length > 0)
+			{
+				GUILayout.Label("Recently Played:", labelStyle);
+			}
+			for (int i = 0; i < Boombox.historyEntries.Length; i++)
+			{
+				int index = Boombox.historyEntries.Length - 1 - i;
+				HistoryEntry entry = Boombox.historyEntries[index];
+				if (GUILayout.Button("▶  " + entry.title, smallButtonStyle, GUILayout.Height(30)))
+				{
+					urlInput = entry.url;
+
+					GUI.FocusControl(null);
+					if (IsValidVideoUrl(urlInput))
+					{
+						if (PhotonNetwork.IsConnected)
+						{
+							photonView.RPC("RequestSong", RpcTarget.All, urlInput, PhotonNetwork.LocalPlayer.ActorNumber);
+						}
+						else
+						{
+							//singleplayer
+							boombox.RequestSong(urlInput, PhotonNetwork.LocalPlayer.ActorNumber);
+						}
+					}
+					else
+					{
+						ShowErrorMessage("Invalid Video URL from history!");
+					}
+				}
+			}
+			if (Boombox.historyEntries.Length > 0)
+			{
+				if (GUILayout.Button("Clear History", buttonStyle, GUILayout.Height(30)))
+				{
+					Boombox.clearHistory();
+				}
+			}
+			GUILayout.EndScrollView();	
+			
+			
 			GUI.DragWindow(new Rect(0, 0, windowRect.width, 30));
 		}
 

--- a/BoomBoxCartMod/Util/HistoryEntry.cs
+++ b/BoomBoxCartMod/Util/HistoryEntry.cs
@@ -1,0 +1,14 @@
+namespace BoomboxCartMod;
+
+public class HistoryEntry
+{
+    public string url;
+    public string title;
+
+
+    public HistoryEntry(string url, string title)
+    {
+        this.url = url;
+        this.title = title;
+    }
+}

--- a/BoomBoxCartMod/Util/HistoryEntry.cs
+++ b/BoomBoxCartMod/Util/HistoryEntry.cs
@@ -1,4 +1,4 @@
-namespace BoomboxCartMod;
+namespace BoomBoxCartMod;
 
 public class HistoryEntry
 {

--- a/BoomBoxCartMod/Util/YouTubeDL.cs
+++ b/BoomBoxCartMod/Util/YouTubeDL.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using BepInEx.Logging;
 using System.Text;
 
-namespace BoomBoxCartMod.Util
+namespace BoomboxCartMod
 {
 	public static class YoutubeDL
 	{

--- a/BoomBoxCartMod/Util/YouTubeDL.cs
+++ b/BoomBoxCartMod/Util/YouTubeDL.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using BepInEx.Logging;
 using System.Text;
 
-namespace BoomboxCartMod
+namespace BoomBoxCartMod
 {
 	public static class YoutubeDL
 	{

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Adds a "Boombox" component into the cart with its own UI that plays video links as audio from the cart. 
 Has volume and quality sliders as well to configure the music to your liking. One player can control the 
 Boombox UI at any time, and everyone (with the mod installed) can hear the songs you play too!
+ADDED IN JUYOH'S FORK: History system for easy song playback
 
 Current websites you can play audio from:
  - Youtube
@@ -26,7 +27,7 @@ Reach out to me (link at the end) for issues with any service listed here, or su
 </ol>
 <p>Known Issues:</p>
 <ul>
-    <li>Singleplayer does NOT work at all. Clicking "Host Game" and playing solo works though!</li>
+    <li>FIXED IN JUYOH'S FORK: Singleplayer does NOT work at all. Clicking "Host Game" and playing solo works though!</li>
     <li>Small stutter when audio is downloaded (longer video, longer stutter)</li>
 </ul>
 


### PR DESCRIPTION
Added singleplayer support using simple checks, and bypassing RPC

Song history system, when a client successfully plays a song, it will get added to the history.
Last played can be easily replayed from GUI
History is stored to `REPO/BoomboxedCart/history.txt`

I had to make some local changes in order for me to build for myself, so please let me know if this works on your machine.

See ya! :)